### PR TITLE
Update Farm.vue to use New SpookySwap URL

### DIFF
--- a/frontend/src/components/farms/Farm.vue
+++ b/frontend/src/components/farms/Farm.vue
@@ -338,14 +338,14 @@ export default class Farm extends Vue {
 			if (
 				getDexUrl() === 'https://app.sushi.com' ||
 				getDexUrl() === 'https://pancakeswap.finance' ||
-				getDexUrl() === 'https://spookyswap.finance'
+				getDexUrl() === 'https://spooky.fi'
 			) {
 				openURL(`${getDexUrl()}/add/${this.wbanAddress}/${otherToken}`)
 			} else {
 				openURL(`${getDexUrl()}/#/add/${this.wbanAddress}/${otherToken}`)
 			}
 		} else {
-			if (getDexUrl() === 'https://spookyswap.finance') {
+			if (getDexUrl() === 'https://spooky.fi') {
 				openURL(`${getDexUrl()}/add/${this.wbanAddress}/FTM`)
 			} else {
 				openURL(`${getDexUrl()}/#/add/${this.wbanAddress}/ETH`)


### PR DESCRIPTION
**Issue:** The "Add Liquidity" button for Fantom Farms directs the user to https://spookyswap.finance/ where the user is presented with a warning message stating the following: 
> The SpookySwap URL is migrating to https://spooky.fi This URL will no longer receive updates.


**Solution:** Updated the SpookySwap URL in Farm.vue to point to the new, updated URL provided by SpookySwap (https://spooky.fi/). Updates are located at lines 341 and 348.

![SpookySwap Migration](https://user-images.githubusercontent.com/77074857/167238835-9255da6a-53b2-4472-8c60-78bdd8a05a85.png)